### PR TITLE
Add m_flBaseDamage member

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 majorVersion=5
-minorVersion=6
+minorVersion=7
 maintenanceVersion=0

--- a/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
@@ -5765,5 +5765,28 @@ enum CCSPlayerWeapon_Members
 	* Get params:       Float:get_member(index, member);
 	* Set params:       set_member(index, member, Float:value);
 	*/
-	m_Weapon_flBaseDamage
+	m_Weapon_flBaseDamage,
+
+	/*
+	* Description:      -
+	* Member type:      float
+	* Get params:       Float:get_member(index, member);
+	* Set params:       set_member(index, member, Float:value);
+	*/
+	m_Weapon_flFamasBaseDamageBurst
+
+	/*
+	* Description:      -
+	* Member type:      float
+	* Get params:       Float:get_member(index, member);
+	* Set params:       set_member(index, member, Float:value);
+	*/
+	m_Weapon_flM4A1BaseDamageSil,
+	/*
+	* Description:      -
+	* Member type:      float
+	* Get params:       Float:get_member(index, member);
+	* Set params:       set_member(index, member, Float:value);
+	*/
+	m_Weapon_flUSPBaseDamageSil,
 };

--- a/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
@@ -4701,7 +4701,15 @@ enum CBasePlayerWeapon_Members
 	* Get params:       Float:get_member(index, member);
 	* Set params:       set_member(index, member, Float:value);
 	*/
-	m_Weapon_flLastFireTime
+	m_Weapon_flLastFireTime,
+
+	/*
+	* Description:      -
+	* Member type:      float
+	* Get params:       Float:get_member(index, member);
+	* Set params:       set_member(index, member, Float:value);
+	*/
+	m_Weapon_flBaseDamage
 };
 
 /**

--- a/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
@@ -5766,27 +5766,4 @@ enum CCSPlayerWeapon_Members
 	* Set params:       set_member(index, member, Float:value);
 	*/
 	m_Weapon_flBaseDamage,
-
-	/*
-	* Description:      -
-	* Member type:      float
-	* Get params:       Float:get_member(index, member);
-	* Set params:       set_member(index, member, Float:value);
-	*/
-	m_Weapon_flFamasBaseDamageBurst
-
-	/*
-	* Description:      -
-	* Member type:      float
-	* Get params:       Float:get_member(index, member);
-	* Set params:       set_member(index, member, Float:value);
-	*/
-	m_Weapon_flM4A1BaseDamageSil,
-	/*
-	* Description:      -
-	* Member type:      float
-	* Get params:       Float:get_member(index, member);
-	* Set params:       set_member(index, member, Float:value);
-	*/
-	m_Weapon_flUSPBaseDamageSil,
 };

--- a/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
@@ -5760,7 +5760,7 @@ enum CCSPlayerWeapon_Members
 	m_Weapon_bHasSecondaryAttack = BEGIN_MEMBER_REGION(csplayerweapon),
 
 	/*
-	* Description:      -
+	* Description:      Basic damage that weapon deals before any multiplier, such as hitgroup, armor, distance and bullet penetration
 	* Member type:      float
 	* Get params:       Float:get_member(index, member);
 	* Set params:       set_member(index, member, Float:value);

--- a/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
@@ -4702,14 +4702,6 @@ enum CBasePlayerWeapon_Members
 	* Set params:       set_member(index, member, Float:value);
 	*/
 	m_Weapon_flLastFireTime,
-
-	/*
-	* Description:      -
-	* Member type:      float
-	* Get params:       Float:get_member(index, member);
-	* Set params:       set_member(index, member, Float:value);
-	*/
-	m_Weapon_flBaseDamage
 };
 
 /**
@@ -5766,4 +5758,12 @@ enum CCSPlayerWeapon_Members
 	* Set params:       set_member(index, member, bool:value);
 	*/
 	m_Weapon_bHasSecondaryAttack = BEGIN_MEMBER_REGION(csplayerweapon),
+
+	/*
+	* Description:      -
+	* Member type:      float
+	* Get params:       Float:get_member(index, member);
+	* Set params:       set_member(index, member, Float:value);
+	*/
+	m_Weapon_flBaseDamage
 };

--- a/reapi/include/cssdk/dlls/API/CSPlayerWeapon.h
+++ b/reapi/include/cssdk/dlls/API/CSPlayerWeapon.h
@@ -41,6 +41,8 @@ public:
 
 public:
 	bool m_bHasSecondaryAttack;
+	float m_flBaseDamage;
+	float m_flFamasBaseDamageBurst;
 };
 
 // Inlines

--- a/reapi/include/cssdk/dlls/API/CSPlayerWeapon.h
+++ b/reapi/include/cssdk/dlls/API/CSPlayerWeapon.h
@@ -43,6 +43,8 @@ public:
 	bool m_bHasSecondaryAttack;
 	float m_flBaseDamage;
 	float m_flFamasBaseDamageBurst;
+	float m_flM4A1BaseDamageSil;
+	float m_flUSPBaseDamageSil;
 };
 
 // Inlines

--- a/reapi/include/cssdk/dlls/API/CSPlayerWeapon.h
+++ b/reapi/include/cssdk/dlls/API/CSPlayerWeapon.h
@@ -42,9 +42,6 @@ public:
 public:
 	bool m_bHasSecondaryAttack;
 	float m_flBaseDamage;
-	float m_flFamasBaseDamageBurst;
-	float m_flM4A1BaseDamageSil;
-	float m_flUSPBaseDamageSil;
 };
 
 // Inlines

--- a/reapi/include/cssdk/dlls/weapons.h
+++ b/reapi/include/cssdk/dlls/weapons.h
@@ -306,8 +306,6 @@ public:
 	// hle time creep vars
 	float m_flPrevPrimaryAttack;
 	float m_flLastFireTime;
-
-	float m_flBaseDamage;
 };
 
 class CBasePlayerAmmo: public CBaseEntity {

--- a/reapi/include/cssdk/dlls/weapons.h
+++ b/reapi/include/cssdk/dlls/weapons.h
@@ -306,6 +306,8 @@ public:
 	// hle time creep vars
 	float m_flPrevPrimaryAttack;
 	float m_flLastFireTime;
+
+	float m_flBaseDamage;
 };
 
 class CBasePlayerAmmo: public CBaseEntity {

--- a/reapi/src/member_list.cpp
+++ b/reapi/src/member_list.cpp
@@ -771,8 +771,7 @@ member_t memberlist_baseweapon[] = {
 	BASEWPN_MEMBERS(usFireGlock18),
 	BASEWPN_MEMBERS(usFireFamas),
 	BASEWPN_MEMBERS(flPrevPrimaryAttack),
-	BASEWPN_MEMBERS(flLastFireTime),
-	BASEWPN_MEMBERS(flBaseDamage),
+	BASEWPN_MEMBERS(flLastFireTime)
 };
 
 member_t memberlist_weaponbox[] = {
@@ -995,7 +994,8 @@ member_t memberlist_mapinfo[] = {
 };
 
 member_t memberlist_csplayerweapon[] = {
-	CSPLWPN_MEMBERS(bHasSecondaryAttack)
+	CSPLWPN_MEMBERS(bHasSecondaryAttack),
+	CSPLWPN_MEMBERS(flBaseDamage)
 };
 
 memberlist_t memberlist;

--- a/reapi/src/member_list.cpp
+++ b/reapi/src/member_list.cpp
@@ -996,9 +996,6 @@ member_t memberlist_mapinfo[] = {
 member_t memberlist_csplayerweapon[] = {
 	CSPLWPN_MEMBERS(bHasSecondaryAttack),
 	CSPLWPN_MEMBERS(flBaseDamage),
-	CSPLWPN_MEMBERS(flFamasBaseDamageBurst),
-	CSPLWPN_MEMBERS(flM4A1BaseDamageSil),
-	CSPLWPN_MEMBERS(flUSPBaseDamageSil),
 };
 
 memberlist_t memberlist;

--- a/reapi/src/member_list.cpp
+++ b/reapi/src/member_list.cpp
@@ -772,6 +772,7 @@ member_t memberlist_baseweapon[] = {
 	BASEWPN_MEMBERS(usFireFamas),
 	BASEWPN_MEMBERS(flPrevPrimaryAttack),
 	BASEWPN_MEMBERS(flLastFireTime),
+	BASEWPN_MEMBERS(flBaseDamage),
 };
 
 member_t memberlist_weaponbox[] = {

--- a/reapi/src/member_list.cpp
+++ b/reapi/src/member_list.cpp
@@ -995,7 +995,10 @@ member_t memberlist_mapinfo[] = {
 
 member_t memberlist_csplayerweapon[] = {
 	CSPLWPN_MEMBERS(bHasSecondaryAttack),
-	CSPLWPN_MEMBERS(flBaseDamage)
+	CSPLWPN_MEMBERS(flBaseDamage),
+	CSPLWPN_MEMBERS(flFamasBaseDamageBurst),
+	CSPLWPN_MEMBERS(flM4A1BaseDamageSil),
+	CSPLWPN_MEMBERS(flUSPBaseDamageSil),
 };
 
 memberlist_t memberlist;

--- a/reapi/src/member_list.h
+++ b/reapi/src/member_list.h
@@ -1043,4 +1043,7 @@ enum CSPlayerWeapon_Members
 {
 	m_Weapon_bHasSecondaryAttack = BEGIN_MEMBER_REGION(csplayerweapon),
 	m_Weapon_flBaseDamage,
+	m_Weapon_flFamasBaseDamageBurst,
+	m_Weapon_flM4A1BaseDamageSil,
+	m_Weapon_flUSPBaseDamageSil,
 };

--- a/reapi/src/member_list.h
+++ b/reapi/src/member_list.h
@@ -1042,4 +1042,5 @@ enum MapInfo_Members
 enum CSPlayerWeapon_Members
 {
 	m_Weapon_bHasSecondaryAttack = BEGIN_MEMBER_REGION(csplayerweapon),
+	m_Weapon_flBaseDamage,
 };

--- a/reapi/src/member_list.h
+++ b/reapi/src/member_list.h
@@ -781,7 +781,9 @@ enum CBasePlayerWeapon_Members
 	m_Weapon_usFireGlock18,
 	m_Weapon_usFireFamas,
 	m_Weapon_flPrevPrimaryAttack,
-	m_Weapon_flLastFireTime
+	m_Weapon_flLastFireTime,
+
+	m_Weapon_flBaseDamage
 };
 
 enum CWeaponBox_Members

--- a/reapi/src/member_list.h
+++ b/reapi/src/member_list.h
@@ -782,8 +782,6 @@ enum CBasePlayerWeapon_Members
 	m_Weapon_usFireFamas,
 	m_Weapon_flPrevPrimaryAttack,
 	m_Weapon_flLastFireTime,
-
-	m_Weapon_flBaseDamage
 };
 
 enum CWeaponBox_Members
@@ -1043,7 +1041,4 @@ enum CSPlayerWeapon_Members
 {
 	m_Weapon_bHasSecondaryAttack = BEGIN_MEMBER_REGION(csplayerweapon),
 	m_Weapon_flBaseDamage,
-	m_Weapon_flFamasBaseDamageBurst,
-	m_Weapon_flM4A1BaseDamageSil,
-	m_Weapon_flUSPBaseDamageSil,
 };


### PR DESCRIPTION
Creating m_flBaseDamage member that change basic damage of weapons deals before any multiplier, such as hitgroup, armor, distance and bullet penetration.