### PR TITLE
Fix ``TimeBasedDamage enum`` typo at cssdk_const.inc

### DIFF
--- a/reapi/extra/amxmodx/scripting/include/cssdk_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/cssdk_const.inc
@@ -900,7 +900,7 @@ enum WeaponIdType
 */
 enum TimeBasedDamage
 {
-	ITDB_PRALYZE,
+	ITDB_PARALYZE,
 	ITDB_NERVEGAS,
 	ITDB_POISON,
 	ITDB_RADIATION,

--- a/reapi/extra/amxmodx/scripting/include/cssdk_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/cssdk_const.inc
@@ -897,6 +897,7 @@ enum WeaponIdType
 
 /**
 * For CBaseMonster::m_rgbTimeBasedDamage
+* prefix should be ITBD_
 */
 enum TimeBasedDamage
 {


### PR DESCRIPTION
ITDB_PARALYZE enum

according to:
Rehlds: https://github.com/dreamstalker/rehlds/blob/6a916d766b2f766ed9a45f9f008b3f7b737e3c89/rehlds/dlls/cbase.h#L651-L659

Regamedll:
https://github.com/s1lentq/ReGameDLL_CS/blob/master/regamedll/dlls/basemonster.h#L35-L46