### PR TITLE
Fix GiveC4 hook callback return type

### DIFF
--- a/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_gamedll_const.inc
@@ -1165,6 +1165,7 @@ enum GamedllFunc_CSGameRules
 
 	/*
 	* Description:      -
+	* Return type:      CBasePlayer * (Entity index of player)
 	* Params:           ()
 	*/
 	RG_CSGameRules_GiveC4,

--- a/reapi/include/cssdk/dlls/regamedll_api.h
+++ b/reapi/include/cssdk/dlls/regamedll_api.h
@@ -339,8 +339,8 @@ typedef IHookChain<void> IReGameHook_CSGameRules_RemoveGuns;
 typedef IHookChainRegistry<void> IReGameHookRegistry_CSGameRules_RemoveGuns;
 
 // CHalfLifeMultiplay::GiveC4 hook
-typedef IHookChain<void> IReGameHook_CSGameRules_GiveC4;
-typedef IHookChainRegistry<void> IReGameHookRegistry_CSGameRules_GiveC4;
+typedef IHookChain<CBasePlayer *> IReGameHook_CSGameRules_GiveC4;
+typedef IHookChainRegistry<CBasePlayer *> IReGameHookRegistry_CSGameRules_GiveC4;
 
 // CHalfLifeMultiplay::ChangeLevel hook
 typedef IHookChain<void> IReGameHook_CSGameRules_ChangeLevel;

--- a/reapi/src/hook_callback.cpp
+++ b/reapi/src/hook_callback.cpp
@@ -972,14 +972,14 @@ void CSGameRules_RemoveGuns(IReGameHook_CSGameRules_RemoveGuns *chain)
 	callVoidForward(RG_CSGameRules_RemoveGuns, original);
 }
 
-void CSGameRules_GiveC4(IReGameHook_CSGameRules_GiveC4 *chain)
+CBasePlayer *CSGameRules_GiveC4(IReGameHook_CSGameRules_GiveC4 *chain)
 {
 	auto original = [chain]()
 	{
-		chain->callNext();
+		return indexOfPDataAmx(chain->callNext());
 	};
 
-	callVoidForward(RG_CSGameRules_GiveC4, original);
+	return getPrivate<CBasePlayer>(callForward<size_t>(RG_CSGameRules_GiveC4, original));
 }
 
 void CSGameRules_ChangeLevel(IReGameHook_CSGameRules_ChangeLevel *chain)

--- a/reapi/src/hook_callback.h
+++ b/reapi/src/hook_callback.h
@@ -476,7 +476,7 @@ void CSGameRules_CleanUpMap(IReGameHook_CSGameRules_CleanUpMap *chain);
 void CSGameRules_RestartRound(IReGameHook_CSGameRules_RestartRound *chain);
 void CSGameRules_CheckWinConditions(IReGameHook_CSGameRules_CheckWinConditions *chain);
 void CSGameRules_RemoveGuns(IReGameHook_CSGameRules_RemoveGuns *chain);
-void CSGameRules_GiveC4(IReGameHook_CSGameRules_GiveC4 *chain);
+CBasePlayer *CSGameRules_GiveC4(IReGameHook_CSGameRules_GiveC4 *chain);
 void CSGameRules_ChangeLevel(IReGameHook_CSGameRules_ChangeLevel *chain);
 void CSGameRules_GoToIntermission(IReGameHook_CSGameRules_GoToIntermission *chain);
 void CSGameRules_BalanceTeams(IReGameHook_CSGameRules_BalanceTeams *chain);


### PR DESCRIPTION
CSGameRules::GiveC4 return type changed in headers but not in hook callbacks files.