### PR TITLE
Implement `RH_SV_SendResources` hook

### DIFF
--- a/reapi/extra/amxmodx/scripting/include/reapi_engine_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_engine_const.inc
@@ -100,9 +100,10 @@ enum EngineFunc
 
 	/*
 	* Description:  Called when client it's in the scoreboard
-	* Params:       (const this)
+	* Params:       (const client)
 	*/
 	RH_SV_EmitPings,
+
 	/*
 	* Description:  Called when an entity is created.
 	* Return type:  Edict * (Entity index)
@@ -183,10 +184,10 @@ enum EngineFunc
 	* Params:       (const cmd[], source, id)
 	*/
 	RH_ExecuteServerStringCmd,
-	
+
 	/*
 	* Description:  Called when server sends resources list and location.
-	* Params:       ()
+	* Params:       (const client)
 	*/
 	RH_SV_SendResources,
 

--- a/reapi/extra/amxmodx/scripting/include/reapi_engine_const.inc
+++ b/reapi/extra/amxmodx/scripting/include/reapi_engine_const.inc
@@ -183,6 +183,12 @@ enum EngineFunc
 	* Params:       (const cmd[], source, id)
 	*/
 	RH_ExecuteServerStringCmd,
+	
+	/*
+	* Description:  Called when server sends resources list and location.
+	* Params:       ()
+	*/
+	RH_SV_SendResources,
 
 };
 

--- a/reapi/include/cssdk/engine/rehlds_api.h
+++ b/reapi/include/cssdk/engine/rehlds_api.h
@@ -258,6 +258,10 @@ typedef IVoidHookChainRegistry<const char *> IRehldsHookRegistry_SV_ClientPrintf
 typedef IHookChain<bool, edict_t*, edict_t*> IRehldsHook_SV_AllowPhysent;
 typedef IHookChainRegistry<bool, edict_t*, edict_t*> IRehldsHookRegistry_SV_AllowPhysent;
 
+//SV_SendResources hook
+typedef IVoidHookChain<sizebuf_t *> IRehldsHook_SV_SendResources;
+typedef IVoidHookChainRegistry<sizebuf_t *> IRehldsHookRegistry_SV_SendResources;
+
 class IRehldsHookchains {
 public:
 	virtual ~IRehldsHookchains() { }
@@ -317,6 +321,7 @@ public:
 	virtual IRehldsHookRegistry_SV_AddResource* SV_AddResource() = 0;
 	virtual IRehldsHookRegistry_SV_ClientPrintf* SV_ClientPrintf() = 0;
 	virtual IRehldsHookRegistry_SV_AllowPhysent* SV_AllowPhysent() = 0;
+	virtual IRehldsHookRegistry_SV_SendResources* SV_SendResources() = 0;
 };
 
 struct RehldsFuncs_t {

--- a/reapi/src/hook_callback.cpp
+++ b/reapi/src/hook_callback.cpp
@@ -242,6 +242,16 @@ void ExecuteServerStringCmd(IRehldsHook_ExecuteServerStringCmd* chain, const cha
 	callVoidForward(RH_ExecuteServerStringCmd, original, cmdName, cmdSrc, cmdSrc == src_client ? cl->GetId() + 1 : AMX_NULLENT);
 }
 
+void SV_SendResources(IRehldsHook_SV_SendResources* chain, sizebuf_t *msg)
+{
+	auto original = [chain](sizebuf_t *_msg)
+	{
+		chain->callNext(_msg);
+	};
+
+	callVoidForward(RH_SV_SendResources, original, msg);
+}
+
 /*
 * ReGameDLL functions
 */

--- a/reapi/src/hook_callback.cpp
+++ b/reapi/src/hook_callback.cpp
@@ -242,14 +242,20 @@ void ExecuteServerStringCmd(IRehldsHook_ExecuteServerStringCmd* chain, const cha
 	callVoidForward(RH_ExecuteServerStringCmd, original, cmdName, cmdSrc, cmdSrc == src_client ? cl->GetId() + 1 : AMX_NULLENT);
 }
 
-void SV_SendResources(IRehldsHook_SV_SendResources* chain, sizebuf_t *msg)
+void SV_SendResources_AMXX(SV_SendResources_t *data, IGameClient *cl)
 {
-	auto original = [chain](sizebuf_t *_msg)
+	auto original = [data](int _cl)
 	{
-		chain->callNext(_msg);
+		data->m_chain->callNext(data->m_args);
 	};
 
-	callVoidForward(RH_SV_SendResources, original, msg);
+	callVoidForward(RH_SV_SendResources, original, cl ? cl->GetId() + 1 : AMX_NULLENT);
+}
+
+void SV_SendResources(IRehldsHook_SV_SendResources *chain, sizebuf_t *msg)
+{
+	SV_SendResources_t data(chain, msg);
+	SV_SendResources_AMXX(&data, g_RehldsFuncs->GetHostClient());
 }
 
 /*

--- a/reapi/src/hook_callback.h
+++ b/reapi/src/hook_callback.h
@@ -370,6 +370,7 @@ void Con_Printf(IRehldsHook_Con_Printf *chain, const char *string);
 int PF_precache_generic_I(IRehldsHook_PF_precache_generic_I *chain, const char *s);
 int PF_precache_model_I(IRehldsHook_PF_precache_model_I *chain, char *s);
 int PF_precache_sound_I(IRehldsHook_PF_precache_sound_I *chain, const char *s);
+void SV_SendResources(IRehldsHook_SV_SendResources *chain, sizebuf_t *msg);
 
 struct EventPrecache_args_t
 {

--- a/reapi/src/hook_callback.h
+++ b/reapi/src/hook_callback.h
@@ -370,6 +370,9 @@ void Con_Printf(IRehldsHook_Con_Printf *chain, const char *string);
 int PF_precache_generic_I(IRehldsHook_PF_precache_generic_I *chain, const char *s);
 int PF_precache_model_I(IRehldsHook_PF_precache_model_I *chain, char *s);
 int PF_precache_sound_I(IRehldsHook_PF_precache_sound_I *chain, const char *s);
+
+using SV_SendResources_t = hookdata_t<IRehldsHook_SV_SendResources *, sizebuf_t *>;
+void SV_SendResources_AMXX(SV_SendResources_t *data, IGameClient *cl);
 void SV_SendResources(IRehldsHook_SV_SendResources *chain, sizebuf_t *msg);
 
 struct EventPrecache_args_t

--- a/reapi/src/hook_list.cpp
+++ b/reapi/src/hook_list.cpp
@@ -108,6 +108,7 @@ hook_t hooklist_engine[] = {
 	ENG(SV_ClientPrintf),
 	ENG(SV_AllowPhysent),
 	ENG(ExecuteServerStringCmd),
+	ENG(SV_SendResources),
 
 };
 

--- a/reapi/src/hook_list.cpp
+++ b/reapi/src/hook_list.cpp
@@ -108,8 +108,7 @@ hook_t hooklist_engine[] = {
 	ENG(SV_ClientPrintf),
 	ENG(SV_AllowPhysent),
 	ENG(ExecuteServerStringCmd),
-	ENG(SV_SendResources),
-
+	ENG(SV_SendResources, _AMXX),
 };
 
 #define DLL(h,...) { {}, {}, #h, "ReGameDLL", [](){ return api_cfg.hasReGameDLL(); }, ((!(RG_##h & (MAX_REGION_RANGE - 1)) ? regfunc::current_cell = 1, true : false) || (RG_##h & (MAX_REGION_RANGE - 1)) == regfunc::current_cell++) ? regfunc(h##__VA_ARGS__) : regfunc(#h#__VA_ARGS__), [](){ g_ReGameHookchains->h()->registerHook(&h); }, [](){ g_ReGameHookchains->h()->unregisterHook(&h); }, false}

--- a/reapi/src/hook_list.h
+++ b/reapi/src/hook_list.h
@@ -117,6 +117,7 @@ enum EngineFunc
 	RH_SV_ClientPrintf,
 	RH_SV_AllowPhysent,
 	RH_ExecuteServerStringCmd,
+	RH_SV_SendResources,
 
 	// [...]
 };


### PR DESCRIPTION
Useful to create a custom resource list when requested by a client or to allow multiple download url setup.

Example:
```
/* Sublime AMXX Editor v4.2 */

#include <amxmodx>
#include <reapi>
#include <geoip>

new g_pCvar
new g_szCvar[64]

public plugin_init()
{
	RegisterHookChain(RH_SV_SendResources, "RH_SV_SendResources_Pre")
	RegisterHookChain(RH_SV_SendResources, "RH_SV_SendResources_Post", 1)
}

public plugin_precache()
{
	server_cmd("exec server.cfg")
	server_exec()

	g_pCvar = get_cvar_pointer("sv_downloadurl")
	get_pcvar_string(g_pCvar, g_szCvar, charsmax(g_szCvar))
}

public RH_SV_SendResources_Post()
{
	RequestFrame("SV_SendResFrame")
}

public SV_SendResFrame()
{
	new szCvar[64]
	set_pcvar_string(g_pCvar, g_szCvar)
	get_pcvar_string(g_pCvar, szCvar, charsmax(szCvar))
}

public RH_SV_SendResources_Pre()
{
	new szIP[18], szRez[3], szCvar[64]
	rh_get_net_from(szIP, charsmax(szIP))

	geoip_code2_ex(szIP, szRez)

	if(equali(szRez, "RO"))
	{
		set_pcvar_string(g_pCvar, "test.com")
		get_pcvar_string(g_pCvar, szCvar, charsmax(szCvar))
	}
}
```
