### PR TITLE
Fix setAmxString cutting off the last character of strings

### DIFF
--- a/reapi/src/amxxmodule.cpp
+++ b/reapi/src/amxxmodule.cpp
@@ -238,13 +238,11 @@ char* getAmxString(cell* src, char* dest, size_t max, size_t* len)
 
 void setAmxString(cell* dest, const char* string, size_t max)
 {
-	if (!dest || max == 0)
+	if (!dest)
 		return;
 
-	// reserve 1 cell for term null
-	size_t limit = max - 1;
-
-	while (*string && limit--)
+	// max is the number of chars without the terminator, like charsmax() in Pawn
+	while (*string && max--)
 		*dest++ = (cell)*string++;
 
 	*dest = 0;


### PR DESCRIPTION
Fixes #383

Since 3c08fde setAmxString treats max as the full buffer size including the null terminator, but plugins pass charsmax(buffer) which already excludes it. So every native that returns a string (get_entvar, get_member, etc.) was losing the last character.

This restores the old behavior (copy up to max chars, terminator goes at dest[max]) and keeps the null pointer check.